### PR TITLE
Change base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
+FROM python:3.9
 
 COPY requirements.txt /app/requirements.txt
+
+WORKDIR /app
+
 RUN pip install -r requirements.txt
 
 COPY ./app /app
 
-
+CMD ["gunicorn","main:app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 fasttext
+fastapi
 pyyaml
 pandas
+uvicorn
+gunicorn


### PR DESCRIPTION
This PR changes the default image to the standard one and includes the missing (or implicit) requirements to the `requirements.txt` file.  
Known issue : The resulting image seems to be bigger (1+ Gi) than the current one (500 Mi). I tried building using the `3.9-alpine` tag but the dependencies resolution does not get through. Not sure why.  

I tested this PR for my own usage (running the server locally) and the support for the environnment variables for gunicorn webserver configuration works out of the box. You may still want to do further testing before merging this PR.  